### PR TITLE
Fixed incorrect hardcoded RenderTexture identifier

### DIFF
--- a/Assets/URPGrabPass/Runtime/GrabColorTexturePass.cs
+++ b/Assets/URPGrabPass/Runtime/GrabColorTexturePass.cs
@@ -9,7 +9,6 @@ namespace URPGrabPass.Runtime
     /// </summary>
     public class GrabColorTexturePass : ScriptableRenderPass
     {
-        private const string GrabbedTextureIdentifier = "_GrabbedTexture";
 
         private readonly RTHandle _grabbedTextureHandle;
         private readonly string _grabbedTextureName;
@@ -21,7 +20,7 @@ namespace URPGrabPass.Runtime
         {
             renderPassEvent = timing.ToRenderPassEvent();
             _grabbedTextureName = grabbedTextureName;
-            _grabbedTextureHandle = RTHandles.Alloc(GrabbedTextureIdentifier, GrabbedTextureIdentifier);
+            _grabbedTextureHandle = RTHandles.Alloc(_grabbedTextureName, _grabbedTextureName);
             _grabbedTexturePropertyId = Shader.PropertyToID(_grabbedTextureName);
         }
 


### PR DESCRIPTION
The RTHandle's texture identifier is hard-coded to _GrabbedTexture, and cannot actually be altered using the "Grabbed Texture Name" field. Was there a reason for this? Fixed it anyways, multiple grab passes can be added now.